### PR TITLE
Add e2e test dependencies for cypress and aws-cli to image

### DIFF
--- a/.github/workflows/cndx-docker-image.yml
+++ b/.github/workflows/cndx-docker-image.yml
@@ -1,0 +1,24 @@
+name: Publish coindex base docker-image
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  push_to_dockerhub_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          dockerfile: ./aws/Dockerfile
+          # repository: coindexbot/docker-images
+          repository: avimehenwal/docker-images
+          tag_with_ref: true

--- a/.github/workflows/cndx-docker-image.yml
+++ b/.github/workflows/cndx-docker-image.yml
@@ -19,6 +19,5 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           dockerfile: ./aws/Dockerfile
-          # repository: coindexbot/docker-images
-          repository: avimehenwal/docker-images
+          repository: coindexbot/docker-images
           tag_with_ref: true

--- a/.github/workflows/cndx-docker-image.yml
+++ b/.github/workflows/cndx-docker-image.yml
@@ -20,4 +20,5 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           dockerfile: ./aws/Dockerfile
           repository: coindexbot/docker-images
-          tag_with_ref: true
+          tags: latest-aws
+          # tag_with_ref: true

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # docker-images
+
+How to use the image
+
+```bash
+docker run --interactive -tty \
+  coindexbot/docker-images:latest-aws bash
+```

--- a/aws/Dockerfile
+++ b/aws/Dockerfile
@@ -13,6 +13,8 @@ RUN yum install update -y \
   unzip \
   xz \
   zip \
+  xorg-x11-server-Xvfb gtk2-devel gtk3-devel \
+  libnotify-devel GConf2 nss libXScrnSaver alsa-lib \
   yum groupinstall "Development Tools" && \
   yum clean all && \
   rm -rf /var/cache/yum
@@ -30,5 +32,10 @@ RUN curl \
   ln -fs /usr/local/cndx/deps/node-$NODE_VERSION-linux-x64/bin/npx \
   /usr/local/bin/npx && \
   rm -rf node-$NODE_VERSION-linux-x64.tar.xz
+
+RUN curl \
+  https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip \
+  && unzip awscliv2.zip \
+  && ./aws/install
 
 WORKDIR /


### PR DESCRIPTION
## Highlights

1. Add dependencies, aws cli and cypress framework related dependencies
2. Update readme - How to use docker image
3. Add CI task to auto publish image on dockerhub

## ToDo :pushpin: 

CI task would onl work when following registry secrets are added in repository settings.

* [ ] `DOCKER_USERNAME`
* [ ] `DOCKER_PASSWORD`

#### CI Sample run 

```bash
 ~/C/docker-images ? ? feature/b2c-dependencies ± ? act --secret-file .secrets
[Publish coindex base docker-image/Push Docker image to Docker Hub] 🚀  Start image=node:12.6-buster-slim
[Publish coindex base docker-image/Push Docker image to Docker Hub]   🐳  docker run image=node:12.6-buster-slim entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[Publish coindex base docker-image/Push Docker image to Docker Hub]   🐳  docker cp src=/home/avi/COINDEX/docker-images/. dst=/github/workspace
[Publish coindex base docker-image/Push Docker image to Docker Hub] ⭐  Run Check out the repo
[Publish coindex base docker-image/Push Docker image to Docker Hub]   ✅  Success - Check out the repo
[Publish coindex base docker-image/Push Docker image to Docker Hub] ⭐  Run Push to Docker Hub
[Publish coindex base docker-image/Push Docker image to Docker Hub]   ☁  git clone 'https://github.com/docker/build-push-action' # ref=v1
[Publish coindex base docker-image/Push Docker image to Docker Hub]   🐳  docker run image=docker/github-actions:v1 entrypoint=[] cmd=["build-push"]
| Logging in to registry 
| WARNING! Using --password via the CLI is insecure. Use --password-stdin.
| WARNING! Your password will be stored unencrypted in /github/home/.docker/config.json.
| Configure a credential helper to remove this warning. See
| https://docs.docker.com/engine/reference/commandline/login/#credentials-store
| 
| Login Succeeded
| Building image [***/docker-images:feature-b2c-dependencies]
| Sending build context to Docker daemon  113.7kB
| Step 1/7 : FROM amazonlinux:2
|  ---> ba2cc467a2bc
| Step 2/7 : ARG NODE_VERSION=v12.16.2
|  ---> Using cache
|  ---> bbb58c1b1515
| Step 3/7 : RUN yum install update -y   autoconf   gcc   gcc-c++   git   gzip   make   tar   unzip   xz   zip   xorg-x11-server-Xvfb gtk2-devel gtk3-devel   libnotify-devel GConf2 nss libXScrnSaver alsa-lib   yum groupinstall "Development Tools" &&   yum clean all &&   rm -rf /var/cache/yum
|  ---> Using cache
|  ---> fc7ce106041f
| Step 4/7 : WORKDIR /usr/local/cndx/deps
|  ---> Using cache
|  ---> 000d7d91ab83
| Step 5/7 : RUN curl   https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-linux-x64.tar.xz >   node-$NODE_VERSION-linux-x64.tar.xz &&   tar -xf node-$NODE_VERSION-linux-x64.tar.xz &&   ln -fs /usr/local/cndx/deps/node-$NODE_VERSION-linux-x64/bin/node   /usr/local/bin/node &&   ln -fs /usr/local/cndx/deps/node-$NODE_VERSION-linux-x64/bin/npm   /usr/local/bin/npm &&   ln -fs /usr/local/cndx/deps/node-$NODE_VERSION-linux-x64/bin/npx   /usr/local/bin/npx &&   rm -rf node-$NODE_VERSION-linux-x64.tar.xz
|  ---> Using cache
|  ---> 8b4918715a37
| Step 6/7 : RUN curl   https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip   && unzip awscliv2.zip   && ./aws/install
|  ---> Using cache
|  ---> 09c75f9db228
| Step 7/7 : WORKDIR /
|  ---> Using cache
|  ---> 4536ce3bf44b
| Successfully built 4536ce3bf44b
| Successfully tagged ***/docker-images:feature-b2c-dependencies
| Pushing image [***/docker-images:feature-b2c-dependencies]
| The push refers to repository [docker.io/***/docker-images]
f4c0efefa208: Layer already exists 
64a12732be64: Layer already exists 
ed9b82bd50a8: Layer already exists 
e3e1ef0f6f21: Layer already exists 
50c3cd231426: Layer already exists 
feature-b2c-dependencies: digest: sha256:75644b0cc6eee387b824fe1dc0f5d483d8be3e268003e6c09b8a82a38fec108f size: 1373
[Publish coindex base docker-image/Push Docker image to Docker Hub]   ✅  Success - Push to Docker Hub
[Publish coindex base docker-image/Push Docker image to Docker Hub] ⭐  Run Image digest
ERRO[0010] Unable to interpolate string 'echo ${{ steps.docker_build.outputs.digest }}' - [TypeError: Cannot access member 'outputs' of undefined] 
| 
[Publish coindex base docker-image/Push Docker image to Docker Hub]   ✅  Success - Image digest

```